### PR TITLE
FIX: request google fonts via https

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Bitcoin Unlimited</title>
         <link rel="stylesheet" href="/components/bootstrap/dist/css/bootstrap.min.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,600,800' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,600,800' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="/css/main-orange.css">
     </head>
     <body>


### PR DESCRIPTION
This avoid to make browser complaining about bu.info serving mixd
content. This is an example taken from google chrome browser:

Mixed Content: The page at 'https://www.bitcoinunlimited.info/' was
loaded over HTTPS, but requested an insecure stylesheet
'http://fonts.googleapis.com/css?family=Open+Sans:400,700,600,800'. This
request has been blocked; the content must be served over HTTPS.