### PR TITLE
Restrict NodeJS listening to just localhost instead of 0.0.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ app.get('*', function(req, res) {
     res.sendFile(path.join(__dirname, './public/index.html'));
 });
 
-let server = app.listen(8080, function() {
+let server = app.listen(8080, "localhost", function() {
     let host = server.address().address;
     let port = server.address().port;
     console.log('The Bitcoin Unlimited website is now being served at http://%s:%s', host, port);


### PR DESCRIPTION
I see no reason that the port is open to the world - it appears that bitcoinunlimited is served through nginx calling nodejs, and nginx looks up 'localhost' anyways.

This should reduce the vulnerability to DDOS and prevents world-access when developing/testing.