### PR TITLE
Add a link to request a Slack invite

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,7 @@
         "forum": "The Bitcoin Forum",
         "reddit1": "Reddit /r/btc",
         "reddit2": "Reddit /r/bitcoin_unlimited",
+        "slack": "Slack",
         "irc": "##btc on IRC",
         "news": "News",
         "time": "Time to roll out bigger blocks",

--- a/src/public/views/footer.jsx
+++ b/src/public/views/footer.jsx
@@ -74,6 +74,9 @@ export default React.createClass({
                                     <a href="https://reddit.com/r/bitcoin_unlimited">{strings().footer.reddit2}</a>
                                 </li>
                                 <li>
+                                    <a href="mailto:trevinhofmann@gmail.com?subject=Bitcoin%20Unlimited%20Slack%20Invite&body=Hi%21%0D%0A%0D%0ACould+you+please+invite+me+to+the+Bitcoin+Unlimited+Slack+group%3F+My+email+address+is+%5BINSERT+EMAIL+ADDRESS+HERE%5D.%0D%0A%0D%0AThank+you%21">{strings().footer.slack}</a>
+                                </li>
+                                <li>
                                     <a href="https://webchat.freenode.net/?channels=##btc">{strings().footer.irc}</a>
                                 </li>
                             </p>


### PR DESCRIPTION
This adds a 'mailto' link to the footer under "Join Us", shown here:

![image](https://cloud.githubusercontent.com/assets/5055041/22033624/df310d0a-dcae-11e6-8811-f1eff4dac058.png)

Clicking the link should open the user's mail client to create a new message with prepopulated information, shown here:

![image](https://cloud.githubusercontent.com/assets/5055041/22033740/4d3b1278-dcaf-11e6-8377-7ff0e641d046.png)
