### PR TITLE
Fix email message encoding

### DIFF
--- a/src/public/views/footer.jsx
+++ b/src/public/views/footer.jsx
@@ -74,7 +74,7 @@ export default React.createClass({
                                     <a href="https://reddit.com/r/bitcoin_unlimited">{strings().footer.reddit2}</a>
                                 </li>
                                 <li>
-                                    <a href="mailto:trevinhofmann@gmail.com?subject=Bitcoin%20Unlimited%20Slack%20Invite&body=Hi%21%0D%0A%0D%0ACould+you+please+invite+me+to+the+Bitcoin+Unlimited+Slack+group%3F+My+email+address+is+%5BINSERT+EMAIL+ADDRESS+HERE%5D.%0D%0A%0D%0AThank+you%21">{strings().footer.slack}</a>
+                                    <a href="mailto:trevinhofmann@gmail.com?subject=Bitcoin%20Unlimited%20Slack%20Invite&body=Hi%21%0D%0A%0D%0ACould%20you%20please%20invite%20me%20to%20the%20Bitcoin%20Unlimited%20Slack%20group%3F%20My%20email%20address%20is%20%5BINSERT%20EMAIL%20ADDRESS%20HERE%5D.%0D%0A%0D%0AThank%20you%21">{strings().footer.slack}</a>
                                 </li>
                                 <li>
                                     <a href="https://webchat.freenode.net/?channels=##btc">{strings().footer.irc}</a>


### PR DESCRIPTION
`+`s were being used instead of `%20`s. Some email clients replace these with spaces, others do not. This PR should fix the formatting.