### PR TITLE
Mandatory 10s cache for all content

### DIFF
--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -1,3 +1,5 @@
+proxy_cache_path /var/cache/nginx/main_cache levels=1:2 keys_zone=main_cache:1m max_size=100m inactive=5m use_temp_path=off;
+
 server {
   listen 80;
   server_name www.bitcoinunlimited.info;
@@ -13,7 +15,25 @@ server {
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_pass          http://localhost:8080;
-    proxy_read_timeout  90;
+    proxy_read_timeout  3;
     proxy_redirect      http://localhost:8080 http://bitcoinunlimited.info;
+
+    # enable caching in main_cache defined above
+    proxy_cache         main_cache;
+
+    # cache when node.js instance is unreachable. Note that the timeout
+    # has been reduced above to a saner 10s.
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+
+    # lock the cache - serve only one request from node.js and cache all others
+    proxy_cache_lock on;
+
+    # force caching of everything for 10s
+    proxy_ignore_headers Cache-Control;
+    proxy_cache_valid any 10;
+
+    # add header to debug cache functionality. maybe switch off in
+    # production?
+    add_header X-Cache-Status $upstream_cache_status;
   }
 }


### PR DESCRIPTION
Nginx configuration tweak to force-cache all content for 10s. Tests
on localhost with httperf show an increase in requests served (for a single URL)
from  ~500 /s to several thousand per second.

A value of 10s should be low enough to not really impact usability of anything, due
to forced serving of stale content.

Furthermore, the cache settings are set so that cached content
is served in case the node.js instance is unreachable, takes longer than 3s to respond
or returns with status code 500, 502, 503, 504, or is concurrently serving another
request for the same URL.

It might be wise to deprioritize / nice / cgroup the node.js process compared to nginx,
to have a better chance at keeping the site responsible and serving stale files
in case it get DDOS-attacked.