### PR TITLE
Use 'BU signing address' on member modal.

### DIFF
--- a/src/public/views/components/about/memberModal.jsx
+++ b/src/public/views/components/about/memberModal.jsx
@@ -28,7 +28,7 @@ class MemberModal extends React.Component {
         }
 
         if (this.props.member.publicKey) {
-            bitcoin_address = "Bitcoin address: " + this.props.member.publicKey
+            bitcoin_address = "BU signing address: " + this.props.member.publicKey
         }
 
         return (


### PR DESCRIPTION
Rather than 'Bitcoin address' use in 'BU singing address'
on the modal containing the each member bio.

In fact such address is supposed to be used to validate members vote on
a given BUIP proposal and not as a jar tip to receive donations.