### PR TITLE
Changed libqrencode to libqrencode-dev 

### DIFF
--- a/src/public/views/components/download/install-instructions.jsx
+++ b/src/public/views/components/download/install-instructions.jsx
@@ -13,7 +13,7 @@ sudo apt-get install bitcoind bitcoin-qt
 
 const BASH2= `sudo apt-get install git build-essential libtool autotools-dev automake pkg-config
 sudo apt-get install libssl-dev libevent-dev bsdmainutils libboost-all-dev
-sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler libqrencode #opt: only needed if you want bitcoin-qt
+sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler libqrencode-dev #opt: only needed if you want bitcoin-qt
 sudo apt-get install software-properties-common                               #opt: only needed if your wallet uses the old format
 sudo add-apt-repository ppa:bitcoin-unlimited/bu-ppa                          #     this is not needed if your wallet will use the new
 sudo apt-get update                                                           #     format, or if you're not going to use a wallet at all


### PR DESCRIPTION
The build-unix.md document uses libqrencode-dev. This is consistent with that document.