### PR TITLE
Relax caching; enable per-IP rate limiting for vote server

### DIFF
--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -1,4 +1,5 @@
 proxy_cache_path /var/cache/nginx/main_cache levels=1:2 keys_zone=main_cache:1m max_size=100m inactive=5m use_temp_path=off;
+limit_req_zone $binary_remote_addr zone=voting_rate:32m rate=1r/s;
 
 server {
   listen 80;
@@ -34,14 +35,16 @@ server {
     # lock the cache - serve only one request at a time and cache all others
     proxy_cache_lock on;
 
-    # force caching of everything for 10s - this should help when someone
-    # decides to hammer us with requests
-    proxy_ignore_headers Cache-Control;
-    proxy_cache_valid any 10;
+    # cache stuff for 1s - to ensure cache gets filled
+    proxy_cache_valid 1;
 
     # add header to debug cache functionality. maybe switch off in
     # production? shouldn't harm though.
     add_header X-Cache-Status $upstream_cache_status;
+
+    # limit amounts of requests per IP to keep voting server from being
+    # hammered
+    limit_req zone=voting_rate burst=100 nodelay;
   }
 
 


### PR DESCRIPTION
The cache now serves the purpose of serving stale content in case the vote server goes down due to load or other reasons.