### PR TITLE
added public keys and removed members

### DIFF
--- a/src/data/members.json
+++ b/src/data/members.json
@@ -118,12 +118,6 @@
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-31180"
     },
     {
-        "avatar": "jake",
-        "name": "Jake Smith",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-30390"
-    },
-    {
         "avatar": "Lee Adams",
         "name": "Lee Adams",
         "publicKey": "1ruQ2wceuMt83aXQsERyWGxQawHqXERSd",
@@ -146,12 +140,6 @@
         "name": "Tom Harding",
         "publicKey": "1BaKh3EaAjGoaP8BH9AZ4jG7VD3HaC3xoG",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-31163"
-    },
-    {
-        "avatar": "Trevin Hofmann",
-        "name": "Trevin Hofmann",
-        "publicKey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: SKS 1.1.5\nComment: Hostname: pgp.mit.edu\nmQENBFXwhKUBCADiEpy6CuJdQ7+f1wHGPaXENji/BuakNMkQsyvDciKAVmmCEuD96oGHyITr\nnxh2DTkrzBLWotKYy6VcTUXwTehu20MCvZuIFMEgPJq/kEgzKAuqK7K7STJXytF+24dHMhzi\n9h2i8gtFqiSnhD8DASmPe4Ed0dpXeeeRHrrPUVX+TQjkw6MJeHxvusJTU856pmSGeWDQNLPf\nKChpch0Eb+KqUPPMes6vW84EqXyVqonpt6rcZLh/+12X6jPh4HOLj4udkkUPtEJ7ShZpxi+F\nHCm2AYrsvf5X9cWKNhv7Lv7d3Mw6STE8asVppZlbUJubR9dO/cKbyaqGI2J7RAmQBoV3ABEB\nAAG0KFRyZXZpbiBIb2ZtYW5uIDx0cmV2aW5ob2ZtYW5uQGdtYWlsLmNvbT6JATkEEwEIACMF\nAlXwhKUCGwMHCwkIBwMCAQYVCAIJCgsEFgIDAQIeAQIXgAAKCRBzffo9i1h4nhCwB/46pQ25\nNj+BA3TEpZ8ulJVLuIKgu56CDp842h3SY12wnTU4GfowhMoyqbN5edGdx8zx0sVmAP5GQzph\np7DgOSaJAtdj6SbaFHo1bn20+Bj9lLUgRMLVmfsC57XveWVS0YVLqdKOnVSmMNCWqO1QDjfk\nnMa37IZebvwr6uAD2q3gPPoxBJmQk5BYlu/AKGYHHZCZbAdhALfx8V2Ako/5Wk/2vMeF88q+\nC3M9I2olXoa6lhTx0F75FVBCG8O29p0wNNxfmM5Q34949+0rrXy1Mb2z8TXIWc+bN9ndIT3w\nZt3y1GBoFfyQh65dm7fUSHyWLXdCiEbRQFUfzc+JrFkSqNnfuQENBFXwhKUBCACyyN4SMwq1\n/73pTkqrklOpfe6THfLUQb4icq1y04yWFmdT9PUQ4xEMpEGhJAvm7ve8SPCI7Jjd3Ts28M5k\nPe11i9EjvFWw3AzgTSD7Dv/JuzGCyW7CouWluf82QEGuBcv0xUUQmPKXHCe2y3KmMnh8VJQs\nnKTPXlucStS3lOpeYGRokUuZLFSNXTDOlHNeebSogILc6wlHu+mUXEaYtwNAMiXeXDTCTZZW\n7iKw7KCzhy9NoOA53F6HjPGufwnX5gHhbY5jMzXFul3Nlnu150FKGzEnwkuhcNsD37jclvpX\n9AzmMLGltgQCr3YoU1tdIjThfhM6z64Ji+4YlWTXRDmRABEBAAGJAR8EGAEIAAkFAlXwhKUC\nGwwACgkQc336PYtYeJ5yZggAlAsYQtPp5+t4claicXCpX2XfcTNwB0WJo2+DHts3aBSA8/5l\n2T9OWjFUoakrL1scVo3TlewhghBRncgc+nLY9nz1jH9uCqfh+3mCmWJKJ5wAsWY+sRAvZwm6\n865Ej355sF+W4p5tQxy5NqLLvBxx+BqdXxGLNN7LzKMcwG4bZTSgxozF8S70c7WrkePxBo80\n3DuHfzdxMhiVs8TsEcpkYI09TfV0d2F4JdzcSemQGeIu2AICoaEDAFUzI19WPPPyfsOFZmUA\nexWCddoSkZD0Bnh8PgTW4PH7dHqNv/Ue591wh2YLSNqbg4xJ8itgvGCrU2V53e4lXabZmb0b\nNHDx1A==\n=Kk0Y\n-----END PGP PUBLIC KEY BLOCK-----",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-3#post-7966"
     },
     {
         "avatar": "adamstgbit",
@@ -178,28 +166,10 @@
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-3#post-8714"
     },
     {
-        "avatar": "cliff",
-        "name": "",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-5#post-27994"
-    },
-    {
-        "avatar": "cypherdoc",
-        "name": "",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/#post-3930"
-    },
-    {
         "avatar": "freetrader",
         "name": "",
         "publicKey": "1Libre7MGkCXr7pUAEbwihCR9X4quYAyQ4",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-3#post-7903"
-    },
-    {
-        "avatar": "jl777",
-        "name": "",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-4#post-14120"
     },
     {
         "avatar": "kostialevin",
@@ -232,18 +202,6 @@
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-5#post-28078"
     },
     {
-        "avatar": "Richy_T",
-        "name": "",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-5#post-30066"
-    },
-    {
-        "avatar": "sgbett",
-        "name": "",
-        "publicKey": "",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-4#post-14118"
-    },
-    {
         "avatar": "todu",
         "name": "Tomislav Dugandzic",
         "publicKey": "1E9VsPghjhvPVDJXrbSiCt4Lk7A2DZWtRH",
@@ -266,12 +224,6 @@
         "name": "",
         "publicKey": "1Czsw6Tp4H7uQC6W9fcAtGyRtoX812JNkU",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-2#post-7145"
-    },
-    {
-        "avatar": "YarkoL",
-        "name": "",
-        "publicKey": "https://bitco.in/forum/threads/a-call-for-members-signing-bitcoin-addresses-or-pgp-public-keys.773/#post-9457",
-        "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-3#post-8933"
     },
     {
         "avatar": "Zanglebert Bingledack",

--- a/src/data/members.json
+++ b/src/data/members.json
@@ -73,7 +73,7 @@
     {
         "avatar": "Haiyang",
         "name": "Haipo Yang",
-        "publicKey": "",
+        "publicKey": "18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-31181",
         "photoUrl": "img/about/Haipo_Yang.png",
         "title": "CEO ViaBTC / BU member",
@@ -114,7 +114,7 @@
     {
         "avatar": "Emil Oldenburg",
         "name": "Emil Oldenburg",
-        "publicKey": "",
+        "publicKey": "1KvZmH4iJbenBpJRMUrsykWfCjDBNAdJuZ",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-31180"
     },
     {
@@ -138,13 +138,13 @@
     {
         "avatar": "tim potter",
         "name": "Tim Potter",
-        "publicKey": "",
+        "publicKey": "1LPTCsvUatVH4Z9UsScJHHZTPjpJRqepNm",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-5#post-28223"
     },
     {
         "avatar": "dgenr8",
         "name": "Tom Harding",
-        "publicKey": "http://keybase.io/dgenr8",
+        "publicKey": "1BaKh3EaAjGoaP8BH9AZ4jG7VD3HaC3xoG",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-6#post-31163"
     },
     {
@@ -156,7 +156,7 @@
     {
         "avatar": "adamstgbit",
         "name": "",
-        "publicKey": "",
+        "publicKey": "17sudmxFpCxW2aeKUV4ZnkuDw7UtnkHkCM",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-7#post-31750"
     },
     {
@@ -210,7 +210,7 @@
     {
         "avatar": "kyuupichan",
         "name": "",
-        "publicKey": "",
+        "publicKey": "1BH8E3TkuJMCcH5WGD11kVweKZuhh6vb7V",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-7#post-33488"
     },
     {
@@ -246,7 +246,7 @@
     {
         "avatar": "todu",
         "name": "Tomislav Dugandzic",
-        "publicKey": "",
+        "publicKey": "1E9VsPghjhvPVDJXrbSiCt4Lk7A2DZWtRH",
         "link": "https://bitco.in/forum/threads/bitcoin-unlimited-membership-join-us.208/page-8#post-34058"
     },
     {


### PR DESCRIPTION
The public keys are according to the current member page (https://www.bitcoinunlimited.info/voting/render/member_list/5f7e99a37aea4babc998543fb194218067c3a4ca9f810e34523e4087acf0f53e)

I have removed members based on when they voted the last time.


Avatar | last vote | vote link
-- | -- | --
jake | 15.03.17 | https://bitco.in/forum/threads/voting-is-closed-for-buips-43-46-47-48.1888/page-2#post-35976
Trevin Hofmann | 13.03.17 | https://bitco.in/forum/threads/voting-is-closed-for-buips-43-46-47-48.1888/#post-35800
cliff | never |  
cypherdoc | 10.11.16 | https://bitco.in/forum/threads/voting-is-closed-for-buips-23-33-34-35-36.1572/page-2#post-30563
jl777 | never |  
Richy_T | never |  
sgbett | never |  
YarkoL | 03.03.16 | https://bitco.in/forum/threads/voting-is-closed-for-buips-16-17-18-19.1129/#post-18939

