### PR TITLE
Fix switched signatures, add 1400&15** to old releases

### DIFF
--- a/src/public/views/components/download/olderReleases.jsx
+++ b/src/public/views/components/download/olderReleases.jsx
@@ -362,6 +362,11 @@ class OfficialRelease extends React.Component {
         return (
             <div className="pt2">
                 <Section
+                    title='BUcash-1.4.0.0'
+                    body={ this.renderVBUcash1400Body() }
+                    expanded={ false } />
+
+                <Section
                     title='BUcash-1.3.0.1'
                     body={ this.renderVBUcash1301Body() }
                     expanded={ false } />

--- a/src/public/views/components/download/olderReleases.jsx
+++ b/src/public/views/components/download/olderReleases.jsx
@@ -23,9 +23,85 @@ import SignaturesBUcash1201 from './signatures_BUcash1-2-0-1.jsx'
 import SignaturesBUcash1300 from './signatures_BUcash1-3-0-0.jsx'
 import SignaturesBUcash1301 from './signatures_BUcash1-3-0-1.jsx'
 import SignaturesBUcash1400 from './signatures_BUcash1-4-0-0.jsx'
+import SignaturesBUcash1500 from './signatures_BUcash1-5-0-0.jsx'
+import SignaturesBUcash1501 from './signatures_BUcash1-5-0-1.jsx'
+import SignaturesBUcash1502 from './signatures_BUcash1-5-0-2.jsx'
+import SignaturesBUcash1510 from './signatures_BUcash1-5-1-0.jsx'
 
 
 class OfficialRelease extends React.Component {
+    renderVBUcash1510Body() {
+        return (
+            <Release
+                osx64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-osx64.tar.gz'
+                osx32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-osx.tar.gz'
+                osxDmg='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-osx.dmg'
+                windows64Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-win64-setup.exe'
+                windows32Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-win32-setup.exe'
+                linux64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-linux64.tar.gz'
+                linux32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-linux32.tar.gz'
+                arm64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-arm64.tar.gz'
+                arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.1.0-arm32.tar.gz'
+                source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.5.1.0'>
+
+                <SignaturesBUcash1510 />
+            </Release>
+        )
+    }
+    renderVBUcash1502Body() {
+        return (
+            <Release
+                osx64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-osx64.tar.gz'
+                osx32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-osx.tar.gz'
+                osxDmg='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-osx.dmg'
+                windows64Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-win64-setup.exe'
+                windows32Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-win32-setup.exe'
+                linux64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-linux64.tar.gz'
+                linux32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-linux32.tar.gz'
+                arm64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-arm64.tar.gz'
+                arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.2-arm32.tar.gz'
+                source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.5.0.2'>
+
+                <SignaturesBUcash1502 />
+            </Release>
+        )
+    }
+    renderVBUcash1501Body() {
+        return (
+            <Release
+                osx64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-osx64.tar.gz'
+                osx32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-osx.tar.gz'
+                osxDmg='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-osx.dmg'
+                windows64Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-win64-setup.exe'
+                windows32Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-win32-setup.exe'
+                linux64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-linux64.tar.gz'
+                linux32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-linux32.tar.gz'
+                arm64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-arm64.tar.gz'
+                arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.1-arm32.tar.gz'
+                source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.5.0.1'>
+
+                <SignaturesBUcash1501 />
+            </Release>
+        )
+    }
+    renderVBUcash1500Body() {
+        return (
+            <Release
+                osx64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-osx64.tar.gz'
+                osx32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-osx.tar.gz'
+                osxDmg='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-osx.dmg'
+                windows64Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-win64-setup.exe'
+                windows32Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-win32-setup.exe'
+                linux64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-linux64.tar.gz'
+                linux32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-linux32.tar.gz'
+                arm64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-arm64.tar.gz'
+                arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.5.0.0-arm32.tar.gz'
+                source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.5.0.0'>
+
+                <SignaturesBUcash1500 />
+            </Release>
+        )
+    }
     renderVBUcash1400Body() {
         return (
             <Release
@@ -361,6 +437,26 @@ class OfficialRelease extends React.Component {
     render() {
         return (
             <div className="pt2">
+                <Section
+                    title='BUcash-1.5.1.0'
+                    body={ this.renderVBUcash1510Body() }
+                    expanded={ false } />
+
+                <Section
+                    title='BUcash-1.5.0.2'
+                    body={ this.renderVBUcash1502Body() }
+                    expanded={ false } />
+
+                <Section
+                    title='BUcash-1.5.0.1'
+                    body={ this.renderVBUcash1501Body() }
+                    expanded={ false } />
+
+                <Section
+                    title='BUcash-1.5.0.0'
+                    body={ this.renderVBUcash1500Body() }
+                    expanded={ false } />
+
                 <Section
                     title='BUcash-1.4.0.0'
                     body={ this.renderVBUcash1400Body() }

--- a/src/public/views/components/download/olderReleases.jsx
+++ b/src/public/views/components/download/olderReleases.jsx
@@ -183,7 +183,7 @@ class OfficialRelease extends React.Component {
                 arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.2.0-arm32.tar.gz'
                 source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/v1.0.2.0'>
 
-                <Signatures1014 />
+                <Signatures1020 />
             </Release>
         )
     }
@@ -201,7 +201,7 @@ class OfficialRelease extends React.Component {
                 arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/bitcoinUnlimited-1.0.1.4-arm32.tar.gz'
                 source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/v1.0.1.4'>
 
-                <Signatures1020 />
+                <Signatures1014 />
             </Release>
         )
     }

--- a/src/public/views/components/download/olderReleases.jsx
+++ b/src/public/views/components/download/olderReleases.jsx
@@ -22,8 +22,28 @@ import SignaturesBUcash1200 from './signatures_BUcash1-2-0-0.jsx'
 import SignaturesBUcash1201 from './signatures_BUcash1-2-0-1.jsx'
 import SignaturesBUcash1300 from './signatures_BUcash1-3-0-0.jsx'
 import SignaturesBUcash1301 from './signatures_BUcash1-3-0-1.jsx'
+import SignaturesBUcash1400 from './signatures_BUcash1-4-0-0.jsx'
+
 
 class OfficialRelease extends React.Component {
+    renderVBUcash1400Body() {
+        return (
+            <Release
+                osx64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-osx64.tar.gz'
+                osx32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-osx.tar.gz'
+                osxDmg='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-osx.dmg'
+                windows64Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-win64-setup.exe'
+                windows32Exe='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-win32-setup.exe'
+                linux64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-linux64.tar.gz'
+                linux32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-linux32.tar.gz'
+                arm64='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-arm64.tar.gz'
+                arm32='https://github.com/BitcoinUnlimited/BitcoinUnlimitedWebDownloadHistory/raw/master/BUcash-1.4.0.0-arm32.tar.gz'
+                source='https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.4.0.0'>
+
+                <SignaturesBUcash1400 />
+            </Release>
+        )
+    }
     renderVBUcash1301Body() {
         return (
             <Release


### PR DESCRIPTION
Signatures 1014 and 1020 were switched, so they have been switched back, and then 1400, 1500, 1501, 1502 and 1510 have been added to old releases.