### PR TITLE
Update install instructions

### DIFF
--- a/src/public/views/components/download/install-instructions.jsx
+++ b/src/public/views/components/download/install-instructions.jsx
@@ -1,6 +1,6 @@
 'use strict';
 
-const BASH0 = `tar xvf BUcash-1.2.0.0-linux64.tar.gz
+const BASH0 = `tar xvf BUcash-1.6.0.0-linux64.tar.gz
 cd BUcash-1.2.0/bin/
 nohup ./bitcoin-qt &
 `;
@@ -13,7 +13,7 @@ sudo apt-get install bitcoind bitcoin-qt
 
 const BASH2= `sudo apt-get install git build-essential libtool autotools-dev automake pkg-config
 sudo apt-get install libssl-dev libevent-dev bsdmainutils libboost-all-dev
-sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler libqrencode-dev #opt: only needed if you want bitcoin-qt
+sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler #opt: only needed if you want bitcoin-qt
 sudo apt-get install software-properties-common                               #opt: only needed if your wallet uses the old format
 sudo add-apt-repository ppa:bitcoin-unlimited/bu-ppa                          #     this is not needed if your wallet will use the new
 sudo apt-get update                                                           #     format, or if you're not going to use a wallet at all


### PR DESCRIPTION
- use 1.6.0.0 tar.gz rather than 1.2.0.0
- show how to install qt5 rather than qt4 since we removed support for the latter