### PR TITLE
Use rsync rather than cp if installed to fetch BU binaries

### DIFF
--- a/downloads.sh
+++ b/downloads.sh
@@ -14,6 +14,13 @@ else
     git clone --depth 1 $repo
 fi
 # Clear existing web downloads and copy them to the components path
-rm -rf $components
-mkdir -p $components
-cp -a $downloads/. $components/
+if [ -f /usr/bin/rsync ]
+then
+  mkdir -p $components
+  rsync -a --delete --exclude=.git $downloads/. $components/
+else
+  rm -rf $components
+  mkdir -p $components
+  cp -a $downloads/. $components/
+  rm -rf $components/.git
+fi


### PR DESCRIPTION
While at it remove .git git from the syncing process and make it so
that deleted file in the original repo will be deleted also from
"components" destination.