### PR TITLE
Fixing default new date issue

### DIFF
--- a/src/database/modelProtocols.js
+++ b/src/database/modelProtocols.js
@@ -37,8 +37,8 @@ protocol.setPrimaryKey = data => {
  * @return {Object}      [Modified Object ready for next operation or to be saved.]
  */
 protocol.setCreated = data => {
-    if (data.created === '') {
-        delete data.created;
+    if (!data.created) {
+        data.created = new Date();
     }
     return data;
 }


### PR DESCRIPTION
The schema default values for new Date() seem to be unreliable depending on the environment or server settings. This change provides the new Date() value for the 'created' property via the 'setCreated' pre-save hook, before the schema value is required. The created hook runs on several models and should fix this issue for all of them.

The change has been tested with the default value removed, but it has been left there in this PR.