### PR TITLE
Use npm rather than yarn in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
 - '8'
 install:
-- yarn install
+- npm install
 script:
-- yarn run build
+- npm run build
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
The deploy instructions as stated in the README.md file
are based on npm. Convert .travis.yml to use the same
instructions rather than use yarn