### PR TITLE
Fix relnote link for 1.7.0[.0]

### DIFF
--- a/src/public/views/components/download/releaseNotes.jsx
+++ b/src/public/views/components/download/releaseNotes.jsx
@@ -8,7 +8,7 @@ class ReleaseNotes extends React.Component {
         return (
             <ul>
                 <li className='pb1'>
-                    {strings().download.notes.releasenotes_buc_1_7_0_0} <a className='link--underline dim black' target='_blank' href='https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.7.0.0.md'>{strings().download.notes.here}</a>.
+                    {strings().download.notes.releasenotes_buc_1_7_0_0} <a className='link--underline dim black' target='_blank' href='https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.7.0.md'>{strings().download.notes.here}</a>.
                 </li>
                 <li className='pb1'>
                     {strings().download.notes.releasenotes_buc_1_6_0_1} <a className='link--underline dim black' target='_blank' href='https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.6.0.1.md'>{strings().download.notes.here}</a>.


### PR DESCRIPTION
In the releaseNotes.jsx component, the link for the release notes for 1.7.0 points to a non-existent 1.7.0.0 file, which produces a Github 404.  This should fix that.