### PR TITLE
Update dependencies to fix npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-loading": "^2.0.3",
     "react-modal": "^1.7.7",
     "realm": "^2.17.0",
-    "sanitize-html": "^1.19.1",
+    "sanitize-html": "1.19.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
```
"sanitize-html": "^1.19.1",
```
Crashes npm run build because it chooses an arbitrary, newer version of sanitize-html

When i change it to (Remove the ^), npm run build works:
```
"sanitize-html": "^1.19.1",
```